### PR TITLE
Chrome Webdrivers versioning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,10 @@ Bundler.require(*Rails.groups)
 
 require "jumpstart"
 
+require "webdrivers"
+
+Webdrivers::Chromedriver.required_version = "114.0.5735.90"
+
 module JumpstartApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.


### PR DESCRIPTION
## Description
GitHub Actions are failing due to attached bug. Applied a fix as described @ryanb in [this](https://github.com/titusfortner/webdrivers/issues/247) issue


## Proof
![image](https://github.com/SuperDupr/builder/assets/45170413/ed04aa9d-bb1e-4a4a-99ad-b3a9e3ade6f4)


## Review Context
@sdnorm The attached screenshot is from failing checks on #31 and #37. Please have a look on it and suggest if something else should be done here. I opened this minor tweak PR for now to go green. Looking forward to you